### PR TITLE
failed precondition shouldn't be 500 error

### DIFF
--- a/errors/src/main/java/com/palantir/remoting/api/errors/ErrorType.java
+++ b/errors/src/main/java/com/palantir/remoting/api/errors/ErrorType.java
@@ -39,7 +39,7 @@ public abstract class ErrorType {
         PERMISSION_DENIED(403),
         INVALID_ARGUMENT(400),
         NOT_FOUND(404),
-        FAILED_PRECONDITION(500),
+        FAILED_PRECONDITION(412),
         INTERNAL(500),
         CUSTOM_CLIENT(400),
         CUSTOM_SERVER(500);


### PR DESCRIPTION
returning a 500 for a failed preconditions seems to be the wrong http error code: https://tools.ietf.org/html/rfc7232#section-4.2