### PR TITLE
SerializableError#params now contains unsafe args in addition to safe args

### DIFF
--- a/errors/src/main/java/com/palantir/remoting/api/errors/SerializableError.java
+++ b/errors/src/main/java/com/palantir/remoting/api/errors/SerializableError.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.palantir.logsafe.Arg;
 import java.io.Serializable;
 import java.util.Map;
+import java.util.stream.Collectors;
 import org.immutables.value.Value;
 
 /**
@@ -107,20 +108,19 @@ public abstract class SerializableError implements Serializable {
 
     /**
      * Creates a {@link SerializableError} representation of this exception that derives from the error code and
-     * message, as well as the {@link Arg#isSafeForLogging safe} {@link ServiceException#args parameters}.
+     * message, as well as the {@link Arg#isSafeForLogging safe} and unsafe {@link ServiceException#args parameters}.
      */
     public static SerializableError forException(ServiceException exception) {
-        Builder builder = new Builder()
+        Map<String, String> safeAndUnsafeArgs = exception.getArgs()
+                .stream()
+                .collect(Collectors.toMap(Arg::getName, arg -> arg.getValue().toString()));
+
+        return new Builder()
                 .errorCode(exception.getErrorType().code().name())
                 .errorName(exception.getErrorType().name())
-                .errorInstanceId(exception.getErrorInstanceId());
-        for (Arg<?> arg : exception.getArgs()) {
-            if (arg.isSafeForLogging()) {
-                builder.putParameters(arg.getName(), arg.getValue().toString());
-            }
-        }
-
-        return builder.build();
+                .errorInstanceId(exception.getErrorInstanceId())
+                .putAllParameters(safeAndUnsafeArgs)
+                .build();
     }
 
     // TODO(rfink): Remove once all error producers have switched to errorCode/errorName.

--- a/errors/src/test/java/com/palantir/remoting/api/errors/SerializableErrorTest.java
+++ b/errors/src/test/java/com/palantir/remoting/api/errors/SerializableErrorTest.java
@@ -52,15 +52,20 @@ public final class SerializableErrorTest {
     }
 
     @Test
-    public void forException_should_fail_if_safearg_and_unsafe_arg_keys_collide() {
+    public void forException_arg_key_collisions_just_use_the_last_one() {
+        ErrorType error = ErrorType.INTERNAL;
         ServiceException exception = new ServiceException(
-                ErrorType.INTERNAL,
-                SafeArg.of("collision", 42),
-                UnsafeArg.of("collision", "bar"));
+                error,
+                SafeArg.of("collision", "first"),
+                UnsafeArg.of("collision", "second"));
 
-        assertThatThrownBy(() -> SerializableError.forException(exception))
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessage("Duplicate key 42");
+        SerializableError expected = new SerializableError.Builder()
+                .errorCode(error.code().name())
+                .errorName(error.name())
+                .errorInstanceId(exception.getErrorInstanceId())
+                .putParameters("collision", "second")
+                .build();
+        assertThat(SerializableError.forException(exception)).isEqualTo(expected);
     }
 
     @Test


### PR DESCRIPTION
Currently, products can throw `ServiceExceptions` containing both SafeArgs and UnsafeArgs, but only SafeArgs are included in the final JSON body that is returned from the server.

This PR changes this behaviour to send both safe and unsafe args over the wire.