### PR TITLE
Simplified assertions on ServiceException args, and more helpful error messages

### DIFF
--- a/test-utils/src/main/java/com/palantir/remoting/api/testing/ServiceExceptionAssert.java
+++ b/test-utils/src/main/java/com/palantir/remoting/api/testing/ServiceExceptionAssert.java
@@ -56,22 +56,34 @@ public class ServiceExceptionAssert extends AbstractThrowableAssert<ServiceExcep
         }
     }
 
-    private static class AssertableArgs {
+    private static final class AssertableArgs {
         private final Map<String, Object> safeArgs = new HashMap<>();
         private final Map<String, Object> unsafeArgs = new HashMap<>();
 
         private AssertableArgs(List<Arg<?>> args) {
             args.forEach(arg -> {
                 if (arg.isSafeForLogging()) {
-                    if (safeArgs.put(arg.getName(), arg.getValue()) != null) {
-                        throw new AssertionError(String.format("Duplicate safe arg name '%s'", arg.getName()));
-                    }
+                    assertPutSafe(arg);
                 } else {
-                    if (unsafeArgs.put(arg.getName(), arg.getValue()) != null) {
-                        throw new AssertionError(String.format("Duplicate unsafe arg name '%s'", arg.getName()));
-                    }
+                    assertPutUnsafe(arg);
                 }
             });
+        }
+
+        private void assertPutSafe(Arg<?> arg) {
+            assertPut(safeArgs, arg.getName(), arg.getValue(), "safe");
+        }
+
+        private void assertPutUnsafe(Arg<?> arg) {
+            assertPut(unsafeArgs, arg.getName(), arg.getValue(), "unsafe");
+        }
+
+        private static void assertPut(Map<String, Object> map, String key, Object value, String name) {
+            Object previous = map.put(key, value);
+            if (previous != null) {
+                throw new AssertionError(String.format("Duplicate %s arg name '%s', first value: %s, second value: %s",
+                        name, key, previous, value));
+            }
         }
     }
 }

--- a/test-utils/src/test/java/com/palantir/remoting/api/testing/ServiceExceptionAssertTest.java
+++ b/test-utils/src/test/java/com/palantir/remoting/api/testing/ServiceExceptionAssertTest.java
@@ -34,6 +34,10 @@ public class ServiceExceptionAssertTest {
                 .hasType(actualType)
                 .hasArgs(SafeArg.of("a", "b"), UnsafeArg.of("c", "d"));
 
+        Assertions.assertThat(new ServiceException(actualType, SafeArg.of("a", "b"), UnsafeArg.of("c", "d")))
+                .hasType(actualType)
+                .hasArgs(UnsafeArg.of("c", "d"), SafeArg.of("a", "b")); // Order doesn't matter
+
         assertThatThrownBy(
                 () -> Assertions.assertThat(new ServiceException(actualType)).hasType(ErrorType.INTERNAL))
                 .isInstanceOf(AssertionError.class)
@@ -43,6 +47,12 @@ public class ServiceExceptionAssertTest {
                 () -> Assertions.assertThat(
                         new ServiceException(actualType, SafeArg.of("a", "b"))).hasArgs(SafeArg.of("c", "d")))
                 .isInstanceOf(AssertionError.class)
-                .hasMessage("Expected args to be [d], but found [b]");
+                .hasMessage("Expected safe args to be {c=d}, but found {a=b}");
+
+        assertThatThrownBy(
+                () -> Assertions.assertThat(
+                        new ServiceException(actualType, UnsafeArg.of("a", "b"))).hasArgs(UnsafeArg.of("c", "d")))
+                .isInstanceOf(AssertionError.class)
+                .hasMessage("Expected unsafe args to be {c=d}, but found {a=b}");
     }
 }


### PR DESCRIPTION
- args don't have to be in the 'correct' order since they are named in the assertions
- more helpful error messages that also print the name of the arg, not just its value