### PR TITLE
Add round robin request flag to PartialServiceConfiguration

### DIFF
--- a/service-config/src/main/java/com/palantir/remoting/api/config/service/PartialServiceConfiguration.java
+++ b/service-config/src/main/java/com/palantir/remoting/api/config/service/PartialServiceConfiguration.java
@@ -64,6 +64,11 @@ public interface PartialServiceConfiguration {
     /** Proxy configuration for connecting to the service. If absent, uses system proxy configuration. */
     Optional<ProxyConfiguration> proxyConfiguration();
 
+    /** Enables round robin functionality across the supplied URIs. Defaults to false (where requests are pinned
+     * to a single URI until an error is received).
+     */
+    Optional<Boolean> roundRobinRequests();
+
     static PartialServiceConfiguration of(List<String> uris, Optional<SslConfiguration> sslConfig) {
         return PartialServiceConfiguration.builder()
                 .uris(uris)
@@ -116,6 +121,11 @@ public interface PartialServiceConfiguration {
         @JsonProperty("enable-gcm-cipher-suites")
         Builder enableGcmCipherSuitesKebabCase(Optional<Boolean> enableGcmCipherSuites) {
             return enableGcmCipherSuites(enableGcmCipherSuites);
+        }
+
+        @JsonProperty("round-robin-requests")
+        Builder roundRobinRequestsKebabCase(Optional<Boolean> roundRobinRequests) {
+            return roundRobinRequests(roundRobinRequests);
         }
     }
 }

--- a/service-config/src/main/java/com/palantir/remoting/api/config/service/ServiceConfiguration.java
+++ b/service-config/src/main/java/com/palantir/remoting/api/config/service/ServiceConfiguration.java
@@ -50,6 +50,8 @@ public interface ServiceConfiguration {
 
     Optional<ProxyConfiguration> proxy();
 
+    Optional<Boolean> roundRobinRequests();
+
     static ImmutableServiceConfiguration.Builder builder() {
         return new Builder();
     }

--- a/service-config/src/main/java/com/palantir/remoting/api/config/service/ServiceConfigurationFactory.java
+++ b/service-config/src/main/java/com/palantir/remoting/api/config/service/ServiceConfigurationFactory.java
@@ -83,6 +83,8 @@ public final class ServiceConfigurationFactory {
                 .proxy(orElse(partial.proxyConfiguration(), services.defaultProxyConfiguration()))
                 .enableGcmCipherSuites(
                         orElse(partial.enableGcmCipherSuites(), services.defaultEnableGcmCipherSuites()))
+                .roundRobinRequests(
+                        orElse(partial.roundRobinRequests(), services.defaultRoundRobinRequests()))
                 .build();
     }
 

--- a/service-config/src/main/java/com/palantir/remoting/api/config/service/ServicesConfigBlock.java
+++ b/service-config/src/main/java/com/palantir/remoting/api/config/service/ServicesConfigBlock.java
@@ -90,6 +90,11 @@ public abstract class ServicesConfigBlock {
     @JsonProperty("enableGcmCipherSuites")
     public abstract Optional<Boolean> defaultEnableGcmCipherSuites();
 
+    /** Default enablement of round robin functionality across the supplied URIs. Defaults to false.
+     */
+    @JsonProperty("roundRobinRequests")
+    public abstract Optional<Boolean> defaultRoundRobinRequests();
+
     public static Builder builder() {
         return new Builder();
     }
@@ -130,6 +135,11 @@ public abstract class ServicesConfigBlock {
         @JsonProperty("enable-gcm-cipher-suites")
         Builder defaultEnableGcmCipherSuitesKebabCase(Optional<Boolean> defaultEnableGcmCipherSuites) {
             return defaultEnableGcmCipherSuites(defaultEnableGcmCipherSuites);
+        }
+
+        @JsonProperty("round-robin-requests")
+        Builder defaultRoundRobinRequestsKebabCase(Optional<Boolean> defaultRoundRobinRequests) {
+            return defaultRoundRobinRequests(defaultRoundRobinRequests);
         }
     }
 }

--- a/service-config/src/test/java/com/palantir/remoting/api/config/service/PartialServiceConfigurationTest.java
+++ b/service-config/src/test/java/com/palantir/remoting/api/config/service/PartialServiceConfigurationTest.java
@@ -50,14 +50,16 @@ public final class PartialServiceConfigurationTest {
                 + "\"maxNumRetries\":5,\"backoffSlotSize\":\"1 day\","
                 + "\"enableGcmCipherSuites\":null,"
                 + "\"proxyConfiguration\":{\"hostAndPort\":\"host:80\",\"credentials\":null,"
-                + "\"type\":\"HTTP\"}}";
+                + "\"type\":\"HTTP\"},"
+                + "\"roundRobinRequests\":null}";
         String kebabCase = "{\"api-token\":\"bearerToken\",\"security\":"
                 + "{\"trust-store-path\":\"truststore.jks\",\"trust-store-type\":\"JKS\",\"key-store-path\":null,"
                 + "\"key-store-password\":null,\"key-store-type\":\"JKS\",\"key-store-key-alias\":null},"
                 + "\"connect-timeout\":\"1 day\",\"read-timeout\":\"1 day\",\"write-timeout\":\"1 day\","
                 + "\"max-num-retries\":5,\"backoff-slot-size\":\"1 day\","
                 + "\"uris\":[\"uri1\"],\"proxy-configuration\":{\"host-and-port\":\"host:80\",\"credentials\":null},"
-                + "\"enable-gcm-cipher-suites\":null}";
+                + "\"enable-gcm-cipher-suites\":null,"
+                + "\"round-robin-requests\":null}";
 
         assertThat(mapper.writeValueAsString(serialized)).isEqualTo(camelCase);
         assertThat(mapper.readValue(camelCase, PartialServiceConfiguration.class)).isEqualTo(serialized);
@@ -70,10 +72,12 @@ public final class PartialServiceConfigurationTest {
         String camelCase = "{\"apiToken\":null,\"security\":null,\"uris\":[],\"connectTimeout\":null,"
                 + "\"readTimeout\":null,\"writeTimeout\":null,\"maxNumRetries\":null,\"backoffSlotSize\":null,"
                 + "\"enableGcmCipherSuites\":null,"
-                + "\"proxyConfiguration\":null}";
+                + "\"proxyConfiguration\":null,"
+                + "\"roundRobinRequests\":null}";
         String kebabCase = "{\"api-token\":null,\"security\":null,\"connect-timeout\":null,"
                 + "\"read-timeout\":null,\"write-timeout\":null,\"max-num-retries\":null,\"backoff-slot-size\":null,"
                 + "\"enable-gcm-cipher-suites\":null,"
+                + "\"round-robin-requests\":null,"
                 + "\"uris\":[],\"proxy-configuration\":null}";
 
         assertThat(ObjectMappers.newClientObjectMapper().writeValueAsString(serialized)).isEqualTo(camelCase);

--- a/service-config/src/test/java/com/palantir/remoting/api/config/service/ServiceConfigurationFactoryTests.java
+++ b/service-config/src/test/java/com/palantir/remoting/api/config/service/ServiceConfigurationFactoryTests.java
@@ -188,16 +188,18 @@ public final class ServiceConfigurationFactoryTests {
                 + "{\"service\":{\"apiToken\":null,\"security\":null,\"uris\":[\"uri\"],\"connectTimeout\":null,"
                 + "\"readTimeout\":null,\"writeTimeout\":null,\"maxNumRetries\":null,\"backoffSlotSize\":null,"
                 + "\"enableGcmCipherSuites\":null,"
-                + "\"proxyConfiguration\":null}},\"proxyConfiguration\":"
+                + "\"proxyConfiguration\":null,\"roundRobinRequests\":null}},\"proxyConfiguration\":"
                 + "{\"hostAndPort\":\"host:80\",\"credentials\":null,\"type\":\"HTTP\"},\"connectTimeout\":\"1 day\","
                 + "\"readTimeout\":\"1 day\",\"writeTimeout\":\"1 day\",\"backoffSlotSize\":\"1 day\","
-                + "\"enableGcmCipherSuites\":null}";
+                + "\"enableGcmCipherSuites\":null,"
+                + "\"roundRobinRequests\":null}";
         String kebabCase = "{\"api-token\":\"bearerToken\",\"security\":"
                 + "{\"trust-store-path\":\"truststore.jks\",\"trust-store-type\":\"JKS\",\"key-store-path\":null,"
                 + "\"key-store-password\":null,\"key-store-type\":\"JKS\",\"key-store-key-alias\":null},\"services\":"
                 + "{\"service\":{\"apiToken\":null,\"security\":null,\"connect-timeout\":null,\"read-timeout\":null,"
                 + "\"write-timeout\":null,\"max-num-retries\":null,\"backoffSlotSize\":null,\"uris\":[\"uri\"],"
                 + "\"enable-gcm-cipher-suites\":null,"
+                + "\"round-robin-requests\":null,"
                 + "\"proxy-configuration\":null}},\"proxy-configuration\":"
                 + "{\"host-and-port\":\"host:80\",\"credentials\":null},\"connect-timeout\":\"1 day\","
                 + "\"read-timeout\":\"1 day\",\"write-timeout\":\"1 day\",\"backoff-slot-size\":\"1 day\"}";
@@ -216,10 +218,10 @@ public final class ServiceConfigurationFactoryTests {
         ServicesConfigBlock deserialized = ServicesConfigBlock.builder().build();
         String serializedCamelCase = "{\"apiToken\":null,\"security\":null,\"services\":{},"
                 + "\"proxyConfiguration\":null,\"connectTimeout\":null,\"readTimeout\":null,\"writeTimeout\":null,"
-                + "\"backoffSlotSize\":null,\"enableGcmCipherSuites\":null}";
+                + "\"backoffSlotSize\":null,\"enableGcmCipherSuites\":null,\"roundRobinRequests\":null}";
         String serializedKebabCase = "{\"api-token\":null,\"security\":null,\"services\":{},"
                 + "\"proxy-configuration\":null,\"connect-timeout\":null,\"read-timeout\":null,\"write-timeout\":null,"
-                + "\"backoff-slot-size\":null,\"enable-gcm-cipher-suites\":null}";
+                + "\"backoff-slot-size\":null,\"enable-gcm-cipher-suites\":null,\"round-robin-requests\":null}";
 
         assertThat(ObjectMappers.newClientObjectMapper().writeValueAsString(deserialized))
                 .isEqualTo(serializedCamelCase);


### PR DESCRIPTION
Provide mechanism to override current URL request handling (which pins to a healthy node). This allows for distributed traffic to downstream services (which may not be the case after a rolling restart of their nodes or if all instances of a given client randomly select the same URL).