### PR TITLE
Include ErrorType in ServiceException#getArgs

### DIFF
--- a/errors/src/main/java/com/palantir/remoting/api/errors/SerializableError.java
+++ b/errors/src/main/java/com/palantir/remoting/api/errors/SerializableError.java
@@ -116,7 +116,7 @@ public abstract class SerializableError implements Serializable {
                 .errorName(exception.getErrorType().name())
                 .errorInstanceId(exception.getErrorInstanceId());
 
-        for (Arg<?> arg : exception.getArgs()) {
+        for (Arg<?> arg : exception.getParameters()) {
             builder.putParameters(arg.getName(), Objects.toString(arg.getValue()));
         }
 

--- a/errors/src/main/java/com/palantir/remoting/api/errors/ServiceException.java
+++ b/errors/src/main/java/com/palantir/remoting/api/errors/ServiceException.java
@@ -27,6 +27,7 @@ import javax.annotation.Nullable;
 
 /** A {@link ServiceException} thrown in server-side code to indicate server-side {@link ErrorType error states}. */
 public final class ServiceException extends RuntimeException implements SafeLoggable {
+    public static final String ERROR_TYPE_ARG_NAME = "errorType";
 
     private final ErrorType errorType;
     private final List<Arg<?>> args;  // unmodifiable
@@ -107,7 +108,7 @@ public final class ServiceException extends RuntimeException implements SafeLogg
 
     private static List<Arg<?>> collectArgs(ErrorType errorType, Arg<?>... args) {
         ArrayList<Arg<?>> argList = new ArrayList<>(args.length + 1);
-        argList.add(SafeArg.of("errorType", errorType));
+        argList.add(SafeArg.of(ERROR_TYPE_ARG_NAME, errorType));
         Collections.addAll(argList, args);
         return Collections.unmodifiableList(argList);
     }

--- a/errors/src/main/java/com/palantir/remoting/api/errors/ServiceException.java
+++ b/errors/src/main/java/com/palantir/remoting/api/errors/ServiceException.java
@@ -78,6 +78,20 @@ public final class ServiceException extends RuntimeException implements SafeLogg
         return noArgsMessage;
     }
 
+    @Override
+    public List<Arg<?>> getArgs() {
+        return args;
+    }
+
+    /**
+     * Get Args of this service exception excluding injected/generated Args like errorType.
+     * @return parameters passed to this ServiceException at construction time
+     */
+    public List<Arg<?>> getParameters() {
+        // errorType is always the first argument, so just slice it out
+        return args.subList(1, args.size());
+    }
+
     private static String renderSafeMessage(ErrorType errorType, Arg<?>... args) {
         String message = renderNoArgsMessage(errorType);
 
@@ -111,10 +125,5 @@ public final class ServiceException extends RuntimeException implements SafeLogg
         argList.add(SafeArg.of(ERROR_TYPE_ARG_NAME, errorType));
         Collections.addAll(argList, args);
         return Collections.unmodifiableList(argList);
-    }
-
-    @Override
-    public List<Arg<?>> getArgs() {
-        return args;
     }
 }

--- a/errors/src/test/java/com/palantir/remoting/api/errors/ServiceExceptionTest.java
+++ b/errors/src/test/java/com/palantir/remoting/api/errors/ServiceExceptionTest.java
@@ -18,9 +18,11 @@ package com.palantir.remoting.api.errors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.google.common.collect.ImmutableList;
 import com.palantir.logsafe.Arg;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.UnsafeArg;
+import java.util.List;
 import java.util.UUID;
 import org.junit.Test;
 
@@ -39,6 +41,13 @@ public final class ServiceExceptionTest {
 
         assertThat(ex.getLogMessage()).isEqualTo(EXPECTED_ERROR_MSG);
         assertThat(ex.getMessage()).isEqualTo(EXPECTED_ERROR_MSG + ": {arg1=foo}");
+
+        List<Arg<?>> expectedArgs = ImmutableList.<Arg<?>>builder()
+                .add(SafeArg.of("errorType", ERROR))
+                .add(args)
+                .build();
+
+        assertThat(ex.getArgs()).isEqualTo(expectedArgs);
     }
 
     @Test

--- a/errors/src/test/java/com/palantir/remoting/api/errors/ServiceExceptionTest.java
+++ b/errors/src/test/java/com/palantir/remoting/api/errors/ServiceExceptionTest.java
@@ -43,7 +43,26 @@ public final class ServiceExceptionTest {
         assertThat(ex.getMessage()).isEqualTo(EXPECTED_ERROR_MSG + ": {arg1=foo}");
 
         List<Arg<?>> expectedArgs = ImmutableList.<Arg<?>>builder()
-                .add(SafeArg.of("errorType", ERROR))
+                .add(SafeArg.of(ServiceException.ERROR_TYPE_ARG_NAME, ERROR))
+                .add(args)
+                .build();
+
+        assertThat(ex.getArgs()).isEqualTo(expectedArgs);
+    }
+
+    @Test
+    public void testExceptionMessageWithNameCollisionWithInjectedArgs() {
+        Arg<?>[] args = {
+                SafeArg.of(ServiceException.ERROR_TYPE_ARG_NAME, "foo"),
+                UnsafeArg.of("arg2", 2),
+                UnsafeArg.of("arg3", null)};
+        ServiceException ex = new ServiceException(ERROR, args);
+
+        assertThat(ex.getLogMessage()).isEqualTo(EXPECTED_ERROR_MSG);
+        assertThat(ex.getMessage()).isEqualTo(EXPECTED_ERROR_MSG + ": {errorType=foo}");
+
+        List<Arg<?>> expectedArgs = ImmutableList.<Arg<?>>builder()
+                .add(SafeArg.of(ServiceException.ERROR_TYPE_ARG_NAME, ERROR))
                 .add(args)
                 .build();
 

--- a/test-utils/src/main/java/com/palantir/remoting/api/testing/ServiceExceptionAssert.java
+++ b/test-utils/src/main/java/com/palantir/remoting/api/testing/ServiceExceptionAssert.java
@@ -41,7 +41,8 @@ public class ServiceExceptionAssert extends AbstractThrowableAssert<ServiceExcep
     public final ServiceExceptionAssert hasArgs(Arg<?>... args) {
         isNotNull();
 
-        AssertableArgs actualArgs = new AssertableArgs(actual.getArgs());
+        // fetch getParameters here to exclude any generated/injected args like 'errorType'
+        AssertableArgs actualArgs = new AssertableArgs(actual.getParameters());
         AssertableArgs expectedArgs = new AssertableArgs(ImmutableList.copyOf(args));
 
         failIfNotEqual("Expected safe args to be %s, but found %s", expectedArgs.safeArgs, actualArgs.safeArgs);
@@ -63,10 +64,7 @@ public class ServiceExceptionAssert extends AbstractThrowableAssert<ServiceExcep
         private AssertableArgs(List<Arg<?>> args) {
             args.forEach(arg -> {
                 if (arg.isSafeForLogging()) {
-                    // exclude the injected arg from testing; it's verified in #hasType
-                    if (!arg.getName().equals(ServiceException.ERROR_TYPE_ARG_NAME)) {
-                        assertPutSafe(arg);
-                    }
+                    assertPutSafe(arg);
                 } else {
                     assertPutUnsafe(arg);
                 }

--- a/test-utils/src/main/java/com/palantir/remoting/api/testing/ServiceExceptionAssert.java
+++ b/test-utils/src/main/java/com/palantir/remoting/api/testing/ServiceExceptionAssert.java
@@ -63,7 +63,10 @@ public class ServiceExceptionAssert extends AbstractThrowableAssert<ServiceExcep
         private AssertableArgs(List<Arg<?>> args) {
             args.forEach(arg -> {
                 if (arg.isSafeForLogging()) {
-                    assertPutSafe(arg);
+                    // exclude the injected arg from testing; it's verified in #hasType
+                    if (!arg.getName().equals(ServiceException.ERROR_TYPE_ARG_NAME)) {
+                        assertPutSafe(arg);
+                    }
                 } else {
                     assertPutUnsafe(arg);
                 }


### PR DESCRIPTION
Otherwise when a ServiceException is logged, it's type is only accessible via parsing the string message.