### PR TITLE
Revert root name back to http-remoting-api

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,4 @@
-rootProject.name = 'conjure-java-api'
+rootProject.name = 'conjure-java-client-config'
 
 include 'errors'
 include 'service-config'

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,4 @@
-rootProject.name = 'conjure-java-client-config'
+rootProject.name = 'http-remoting-api'
 
 include 'errors'
 include 'service-config'


### PR DESCRIPTION
Reverts palantir/http-remoting-api#101

Need to keep the root project name the same as the project name in github, or else bintray fails to publish