### PR TITLE
 use JsonAlias for kabab case support

### DIFF
--- a/errors/versions.lock
+++ b/errors/versions.lock
@@ -1,19 +1,19 @@
 {
     "compileClasspath": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.6.7",
+            "locked": "2.9.5",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.6.7",
+            "locked": "2.9.5",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.6.7"
+            "locked": "2.9.5"
         },
         "com.google.code.findbugs:jsr305": {
             "locked": "3.0.1"
@@ -27,19 +27,19 @@
     },
     "runtime": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.6.7",
+            "locked": "2.9.5",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.6.7",
+            "locked": "2.9.5",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.6.7"
+            "locked": "2.9.5"
         },
         "com.google.code.findbugs:jsr305": {
             "locked": "3.0.1"

--- a/extras/jackson-support/versions.lock
+++ b/extras/jackson-support/versions.lock
@@ -1,13 +1,14 @@
 {
     "compileClasspath": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.6.7",
+            "locked": "2.9.5",
             "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.6.7",
+            "locked": "2.9.5",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
@@ -18,7 +19,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.6.7",
+            "locked": "2.9.5",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-guava",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -27,19 +28,19 @@
             ]
         },
         "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.7"
+            "locked": "2.9.5"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-guava": {
-            "locked": "2.6.7"
+            "locked": "2.9.5"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.6.7"
+            "locked": "2.9.5"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.6.7"
+            "locked": "2.9.5"
         },
         "com.fasterxml.jackson.module:jackson-module-afterburner": {
-            "locked": "2.6.7"
+            "locked": "2.9.5"
         },
         "com.google.guava:guava": {
             "locked": "18.0",
@@ -50,13 +51,14 @@
     },
     "runtime": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.6.7",
+            "locked": "2.9.5",
             "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.6.7",
+            "locked": "2.9.5",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
@@ -67,7 +69,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.6.7",
+            "locked": "2.9.5",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-guava",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -76,19 +78,19 @@
             ]
         },
         "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
-            "locked": "2.6.7"
+            "locked": "2.9.5"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-guava": {
-            "locked": "2.6.7"
+            "locked": "2.9.5"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.6.7"
+            "locked": "2.9.5"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.6.7"
+            "locked": "2.9.5"
         },
         "com.fasterxml.jackson.module:jackson-module-afterburner": {
-            "locked": "2.6.7"
+            "locked": "2.9.5"
         },
         "com.google.guava:guava": {
             "locked": "18.0",

--- a/service-config/src/main/java/com/palantir/remoting/api/config/service/PartialServiceConfiguration.java
+++ b/service-config/src/main/java/com/palantir/remoting/api/config/service/PartialServiceConfiguration.java
@@ -17,7 +17,6 @@
 package com.palantir.remoting.api.config.service;
 
 import com.fasterxml.jackson.annotation.JsonAlias;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.palantir.remoting.api.config.ssl.SslConfiguration;

--- a/service-config/src/main/java/com/palantir/remoting/api/config/service/PartialServiceConfiguration.java
+++ b/service-config/src/main/java/com/palantir/remoting/api/config/service/PartialServiceConfiguration.java
@@ -16,6 +16,7 @@
 
 package com.palantir.remoting.api.config.service;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
@@ -32,6 +33,7 @@ import org.immutables.value.Value.Immutable;
 public interface PartialServiceConfiguration {
 
     /** The API token to be used to interact with the service. */
+    @JsonAlias("api-token")
     Optional<BearerToken> apiToken();
 
     /** The SSL configuration needed to interact with the service. */
@@ -41,27 +43,34 @@ public interface PartialServiceConfiguration {
     List<String> uris();
 
     /** Connect timeout for requests. */
+    @JsonAlias("connect-timeout")
     Optional<HumanReadableDuration> connectTimeout();
 
     /** Read timeout for requests. */
+    @JsonAlias("read-timeout")
     Optional<HumanReadableDuration> readTimeout();
 
     /** Write timeout for requests. */
+    @JsonAlias("write-timeout")
     Optional<HumanReadableDuration> writeTimeout();
 
     /** The maximum number of times a failed RPC call should be retried. */
+    @JsonAlias("max-num-retries")
     Optional<Integer> maxNumRetries();
 
     /**
      * The size of one backoff time slot for call retries. For example, an exponential backoff retry algorithm may
      * choose a backoff time in {@code [0, backoffSlotSize * 2^c]} for the c-th retry.
      */
+    @JsonAlias("backoff-slot-size")
     Optional<HumanReadableDuration> backoffSlotSize();
 
     /** Enables slower, but more standard cipher suite support, defaults to false. */
+    @JsonAlias("enable-gcm-cipher-suites")
     Optional<Boolean> enableGcmCipherSuites();
 
     /** Proxy configuration for connecting to the service. If absent, uses system proxy configuration. */
+    @JsonAlias("proxy-configuration")
     Optional<ProxyConfiguration> proxyConfiguration();
 
     static PartialServiceConfiguration of(List<String> uris, Optional<SslConfiguration> sslConfig) {
@@ -75,47 +84,5 @@ public interface PartialServiceConfiguration {
         return new Builder();
     }
 
-    // TODO(jnewman): #317 - remove kebab-case methods when Jackson 2.7 is picked up
-    class Builder extends ImmutablePartialServiceConfiguration.Builder {
-
-        @JsonProperty("api-token")
-        Builder apiTokenKebabCase(Optional<BearerToken> apiToken) {
-            return apiToken(apiToken);
-        }
-
-        @JsonProperty("connect-timeout")
-        Builder connectTimeoutKebabCase(Optional<HumanReadableDuration> connectTimeout) {
-            return connectTimeout(connectTimeout);
-        }
-
-        @JsonProperty("read-timeout")
-        Builder readTimeoutKebabCase(Optional<HumanReadableDuration> readTimeout) {
-            return readTimeout(readTimeout);
-        }
-
-        @JsonProperty("write-timeout")
-        Builder writeTimeoutKebabCase(Optional<HumanReadableDuration> writeTimeout) {
-            return writeTimeout(writeTimeout);
-        }
-
-        @JsonProperty("max-num-retries")
-        Builder maxNumRetriesKebabCase(Optional<Integer> maxNumRetries) {
-            return maxNumRetries(maxNumRetries);
-        }
-
-        @JsonProperty("backoff-slot-size")
-        Builder backoffSlotSizeKebabCase(Optional<HumanReadableDuration> backoffSlotSize) {
-            return backoffSlotSize(backoffSlotSize);
-        }
-
-        @JsonProperty("proxy-configuration")
-        Builder proxyConfigurationKebabCase(Optional<ProxyConfiguration> proxyConfiguration) {
-            return proxyConfiguration(proxyConfiguration);
-        }
-
-        @JsonProperty("enable-gcm-cipher-suites")
-        Builder enableGcmCipherSuitesKebabCase(Optional<Boolean> enableGcmCipherSuites) {
-            return enableGcmCipherSuites(enableGcmCipherSuites);
-        }
-    }
+    class Builder extends ImmutablePartialServiceConfiguration.Builder { }
 }

--- a/service-config/src/main/java/com/palantir/remoting/api/config/service/ProxyConfiguration.java
+++ b/service-config/src/main/java/com/palantir/remoting/api/config/service/ProxyConfiguration.java
@@ -16,6 +16,7 @@
 
 package com.palantir.remoting.api.config.service;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
@@ -54,6 +55,7 @@ public abstract class ProxyConfiguration {
      * com.google.common.net.HostAndPort}, for instance {@code foo.com:80}, {@code 192.168.3.100:8080}, etc.
      */
     @JsonProperty("hostAndPort")
+    @JsonAlias("host-and-port")
     public abstract Optional<String> hostAndPort();
 
     /**
@@ -113,12 +115,5 @@ public abstract class ProxyConfiguration {
         return new Builder();
     }
 
-    // TODO(jnewman): #317 - remove kebab-case methods when Jackson 2.7 is picked up
-    static final class Builder extends ImmutableProxyConfiguration.Builder {
-
-        @JsonProperty("host-and-port")
-        Builder hostAndPortKebabCase(String hostAndPort) {
-            return hostAndPort(hostAndPort);
-        }
-    }
+    static final class Builder extends ImmutableProxyConfiguration.Builder {}
 }

--- a/service-config/src/main/java/com/palantir/remoting/api/config/service/ServicesConfigBlock.java
+++ b/service-config/src/main/java/com/palantir/remoting/api/config/service/ServicesConfigBlock.java
@@ -16,6 +16,7 @@
 
 package com.palantir.remoting.api.config.service;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
@@ -42,6 +43,7 @@ public abstract class ServicesConfigBlock {
      * PartialServiceConfiguration}.
      */
     @JsonProperty("apiToken")
+    @JsonAlias("api-token")
     public abstract Optional<BearerToken> defaultApiToken();
 
     /**
@@ -58,78 +60,47 @@ public abstract class ServicesConfigBlock {
      * Default global proxy configuration for connecting to the services.
      */
     @JsonProperty("proxyConfiguration")
+    @JsonAlias("proxy-configuration")
     public abstract Optional<ProxyConfiguration> defaultProxyConfiguration();
 
     /**
      * Default global connect timeout.
      */
     @JsonProperty("connectTimeout")
+    @JsonAlias("connect-timeout")
     public abstract Optional<HumanReadableDuration> defaultConnectTimeout();
 
     /**
      * Default global read timeout.
      */
     @JsonProperty("readTimeout")
+    @JsonAlias("read-timeout")
     public abstract Optional<HumanReadableDuration> defaultReadTimeout();
 
     /**
      * Default global write timeout.
      */
     @JsonProperty("writeTimeout")
+    @JsonAlias("write-timeout")
     public abstract Optional<HumanReadableDuration> defaultWriteTimeout();
 
     /**
      * Default global backoff slot size, see {@link PartialServiceConfiguration#backoffSlotSize()}.
      */
     @JsonProperty("backoffSlotSize")
+    @JsonAlias("backoff-slot-size")
     public abstract Optional<HumanReadableDuration> defaultBackoffSlotSize();
 
     /**
      * Default enablement of gcm cipher suites, defaults to false.
      */
     @JsonProperty("enableGcmCipherSuites")
+    @JsonAlias("enable-gcm-cipher-suites")
     public abstract Optional<Boolean> defaultEnableGcmCipherSuites();
 
     public static Builder builder() {
         return new Builder();
     }
 
-    // TODO(jnewman): #317 - remove kebab-case methods when Jackson 2.7 is picked up
-    public static final class Builder extends ImmutableServicesConfigBlock.Builder {
-
-        @JsonProperty("api-token")
-        Builder defaultApiTokenKebabCase(Optional<BearerToken> defaultApiToken) {
-            return defaultApiToken(defaultApiToken);
-        }
-
-        @JsonProperty("proxy-configuration")
-        Builder defaultProxyConfigurationKebabCase(Optional<ProxyConfiguration> defaultProxyConfiguration) {
-            return defaultProxyConfiguration(defaultProxyConfiguration);
-        }
-
-        @JsonProperty("connect-timeout")
-        Builder defaultConnectTimeoutKebabCase(Optional<HumanReadableDuration> defaultConnectTimeout) {
-            return defaultConnectTimeout(defaultConnectTimeout);
-        }
-
-        @JsonProperty("read-timeout")
-        Builder defaultReadTimeoutKebabCase(Optional<HumanReadableDuration> defaultReadTimeout) {
-            return defaultReadTimeout(defaultReadTimeout);
-        }
-
-        @JsonProperty("write-timeout")
-        Builder defaultWriteTimeoutKebabCase(Optional<HumanReadableDuration> defaultWriteTimeout) {
-            return defaultWriteTimeout(defaultWriteTimeout);
-        }
-
-        @JsonProperty("backoff-slot-size")
-        Builder defaultBackoffSlotSizeKebabCase(Optional<HumanReadableDuration> defaultBackoffSlotSize) {
-            return defaultBackoffSlotSize(defaultBackoffSlotSize);
-        }
-
-        @JsonProperty("enable-gcm-cipher-suites")
-        Builder defaultEnableGcmCipherSuitesKebabCase(Optional<Boolean> defaultEnableGcmCipherSuites) {
-            return defaultEnableGcmCipherSuites(defaultEnableGcmCipherSuites);
-        }
-    }
+    public static final class Builder extends ImmutableServicesConfigBlock.Builder {}
 }

--- a/service-config/versions.lock
+++ b/service-config/versions.lock
@@ -1,20 +1,20 @@
 {
     "compileClasspath": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.6.7",
+            "locked": "2.9.5",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.6.7",
+            "locked": "2.9.5",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.6.7",
+            "locked": "2.9.5",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.palantir.remoting-api:ssl-config",
@@ -22,7 +22,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.6.7",
+            "locked": "2.9.5",
             "transitive": [
                 "com.palantir.tokens:auth-tokens"
             ]
@@ -42,20 +42,20 @@
     },
     "runtime": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.6.7",
+            "locked": "2.9.5",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.6.7",
+            "locked": "2.9.5",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.6.7",
+            "locked": "2.9.5",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.palantir.remoting-api:ssl-config",
@@ -63,7 +63,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.6.7",
+            "locked": "2.9.5",
             "transitive": [
                 "com.palantir.tokens:auth-tokens"
             ]

--- a/ssl-config/src/main/java/com/palantir/remoting/api/config/ssl/SslConfiguration.java
+++ b/ssl-config/src/main/java/com/palantir/remoting/api/config/ssl/SslConfiguration.java
@@ -16,6 +16,7 @@
 
 package com.palantir.remoting.api.config.ssl;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import java.nio.file.Path;
@@ -36,24 +37,30 @@ public abstract class SslConfiguration {
 
     private static final StoreType DEFAULT_STORE_TYPE = StoreType.JKS;
 
+    @JsonAlias("trust-store-path")
     public abstract Path trustStorePath();
 
     @SuppressWarnings("checkstyle:designforextension")
     @Value.Default
+    @JsonAlias("trust-store-type")
     public StoreType trustStoreType() {
         return DEFAULT_STORE_TYPE;
     }
 
+    @JsonAlias("key-store-path")
     public abstract Optional<Path> keyStorePath();
 
+    @JsonAlias("key-store-password")
     public abstract Optional<String> keyStorePassword();
 
     @SuppressWarnings("checkstyle:designforextension")
     @Value.Default
+    @JsonAlias("key-store-type")
     public StoreType keyStoreType() {
         return DEFAULT_STORE_TYPE;
     }
 
+    @JsonAlias("key-store-key-alias")
     /** Alias of the key that should be used in the key store. If absent, first entry returned by key store is used. */
     public abstract Optional<String> keyStoreKeyAlias();
 
@@ -85,38 +92,5 @@ public abstract class SslConfiguration {
         return new Builder();
     }
 
-    // TODO(jnewman): #317 - remove kebab-case methods when Jackson 2.7 is picked up
-    public static final class Builder extends ImmutableSslConfiguration.Builder {
-
-        @JsonProperty("trust-store-path")
-        Builder trustStorePathKebabCase(Path trustStorePath) {
-            return trustStorePath(trustStorePath);
-        }
-
-        @JsonProperty("trust-store-type")
-        Builder trustStoreTypeKebabCase(StoreType storeType) {
-            return trustStoreType(storeType);
-        }
-
-        @JsonProperty("key-store-path")
-        Builder keyStorePathKebabCase(Optional<Path> keyStorePath) {
-            return keyStorePath(keyStorePath);
-        }
-
-        @JsonProperty("key-store-password")
-        Builder keyStorePasswordKebabCase(Optional<String> keyStorePassword) {
-            return keyStorePassword(keyStorePassword);
-        }
-
-        @JsonProperty("key-store-type")
-        Builder keyStoretypeKebabCase(StoreType keyStoreType) {
-            return keyStoreType(keyStoreType);
-        }
-
-        @JsonProperty("key-store-key-alias")
-        Builder keyStoreKeyAliasKebabCase(Optional<String> keyStoreKeyAlias) {
-            return keyStoreKeyAlias(keyStoreKeyAlias);
-        }
-
-    }
+    public static final class Builder extends ImmutableSslConfiguration.Builder {}
 }

--- a/ssl-config/src/main/java/com/palantir/remoting/api/config/ssl/SslConfiguration.java
+++ b/ssl-config/src/main/java/com/palantir/remoting/api/config/ssl/SslConfiguration.java
@@ -17,7 +17,6 @@
 package com.palantir.remoting.api.config.ssl;
 
 import com.fasterxml.jackson.annotation.JsonAlias;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import java.nio.file.Path;
 import java.util.Optional;

--- a/ssl-config/versions.lock
+++ b/ssl-config/versions.lock
@@ -1,36 +1,36 @@
 {
     "compileClasspath": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.6.7",
+            "locked": "2.9.5",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.6.7",
+            "locked": "2.9.5",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.6.7"
+            "locked": "2.9.5"
         }
     },
     "runtime": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.6.7",
+            "locked": "2.9.5",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.6.7",
+            "locked": "2.9.5",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.6.7"
+            "locked": "2.9.5"
         }
     }
 }

--- a/test-utils/versions.lock
+++ b/test-utils/versions.lock
@@ -1,19 +1,19 @@
 {
     "compileClasspath": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.6.7",
+            "locked": "2.9.5",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.6.7",
+            "locked": "2.9.5",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.6.7",
+            "locked": "2.9.5",
             "transitive": [
                 "com.palantir.remoting-api:errors"
             ]
@@ -67,19 +67,19 @@
     },
     "runtime": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.6.7",
+            "locked": "2.9.5",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.6.7",
+            "locked": "2.9.5",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.6.7",
+            "locked": "2.9.5",
             "transitive": [
                 "com.palantir.remoting-api:errors"
             ]

--- a/tracing/versions.lock
+++ b/tracing/versions.lock
@@ -1,36 +1,36 @@
 {
     "compileClasspath": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.6.7",
+            "locked": "2.9.5",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.6.7",
+            "locked": "2.9.5",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.6.7"
+            "locked": "2.9.5"
         }
     },
     "runtime": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.6.7",
+            "locked": "2.9.5",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.6.7",
+            "locked": "2.9.5",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.6.7"
+            "locked": "2.9.5"
         }
     }
 }

--- a/versions.props
+++ b/versions.props
@@ -1,4 +1,4 @@
-com.fasterxml.jackson.*:jackson-* = 2.6.7
+com.fasterxml.jackson.*:jackson-* = 2.9.5
 com.google.code.findbugs:jsr305 = 3.0.1
 com.google.guava:guava = 18.0
 com.palantir.safe-logging:safe-logging = 0.1.3


### PR DESCRIPTION
htp-remoting/spark are already on jackson 2.9.5. Fixes https://github.com/palantir/http-remoting/issues/317

worth  mentioning https://github.com/palantir/http-remoting/releases/tag/3.33.0 release notes