### PR TITLE
make ProxyConfiguration Builder public

### DIFF
--- a/service-config/src/main/java/com/palantir/conjure/java/api/config/service/ProxyConfiguration.java
+++ b/service-config/src/main/java/com/palantir/conjure/java/api/config/service/ProxyConfiguration.java
@@ -117,5 +117,5 @@ public abstract class ProxyConfiguration {
         return new Builder();
     }
 
-    static final class Builder extends ImmutableProxyConfiguration.Builder {}
+    public static final class Builder extends ImmutableProxyConfiguration.Builder {}
 }


### PR DESCRIPTION
this allows adapter to use builder without checking optionality of both proxy configuration properties. 