### PR TITLE
add `asConjure` methods for configuration classes

### DIFF
--- a/service-config/build.gradle
+++ b/service-config/build.gradle
@@ -4,6 +4,7 @@ apply from: "$rootDir/gradle/publish-jar.gradle"
 
 dependencies {
     compile project(":ssl-config")
+    compile "com.palantir.conjure.java.api:service-config"
     compile "com.palantir.tokens:auth-tokens"
 
     testCompile project(":extras:jackson-support")

--- a/service-config/src/main/java/com/palantir/remoting/api/config/service/BasicCredentials.java
+++ b/service-config/src/main/java/com/palantir/remoting/api/config/service/BasicCredentials.java
@@ -34,6 +34,11 @@ public abstract class BasicCredentials {
     @Value.Parameter
     public abstract String password();
 
+    @Value.Lazy
+    public com.palantir.conjure.java.api.config.service.BasicCredentials asConjure() {
+        return com.palantir.conjure.java.api.config.service.BasicCredentials.of(username(), password());
+    }
+
     public static BasicCredentials of(String username, String password) {
         return ImmutableBasicCredentials.of(username, password);
     }

--- a/service-config/src/main/java/com/palantir/remoting/api/config/service/HumanReadableDuration.java
+++ b/service-config/src/main/java/com/palantir/remoting/api/config/service/HumanReadableDuration.java
@@ -218,4 +218,8 @@ public final class HumanReadableDuration implements Comparable<HumanReadableDura
 
         return Long.compare(toNanoseconds(), other.toNanoseconds());
     }
+
+    public com.palantir.conjure.java.api.config.service.HumanReadableDuration asConjure() {
+        return com.palantir.conjure.java.api.config.service.HumanReadableDuration.valueOf(toString());
+    }
 }

--- a/service-config/src/main/java/com/palantir/remoting/api/config/service/PartialServiceConfiguration.java
+++ b/service-config/src/main/java/com/palantir/remoting/api/config/service/PartialServiceConfiguration.java
@@ -23,6 +23,7 @@ import com.palantir.remoting.api.config.ssl.SslConfiguration;
 import com.palantir.tokens.auth.BearerToken;
 import java.util.List;
 import java.util.Optional;
+import org.immutables.value.Value;
 import org.immutables.value.Value.Immutable;
 
 @Immutable
@@ -71,6 +72,21 @@ public interface PartialServiceConfiguration {
     /** Proxy configuration for connecting to the service. If absent, uses system proxy configuration. */
     @JsonAlias("proxy-configuration")
     Optional<ProxyConfiguration> proxyConfiguration();
+
+    @Value.Lazy
+    default com.palantir.conjure.java.api.config.service.PartialServiceConfiguration asConjure() {
+        return com.palantir.conjure.java.api.config.service.PartialServiceConfiguration.builder()
+                .apiToken(apiToken())
+                .security(security().map(SslConfiguration::asConjure))
+                .addAllUris(uris())
+                .connectTimeout(connectTimeout().map(HumanReadableDuration::asConjure))
+                .readTimeout(readTimeout().map(HumanReadableDuration::asConjure))
+                .maxNumRetries(maxNumRetries())
+                .backoffSlotSize(backoffSlotSize().map(HumanReadableDuration::asConjure))
+                .enableGcmCipherSuites(enableGcmCipherSuites())
+                .proxyConfiguration(proxyConfiguration().map(ProxyConfiguration::asConjure))
+                .build();
+    }
 
     static PartialServiceConfiguration of(List<String> uris, Optional<SslConfiguration> sslConfig) {
         return PartialServiceConfiguration.builder()

--- a/service-config/src/main/java/com/palantir/remoting/api/config/service/PartialServiceConfiguration.java
+++ b/service-config/src/main/java/com/palantir/remoting/api/config/service/PartialServiceConfiguration.java
@@ -81,6 +81,7 @@ public interface PartialServiceConfiguration {
                 .addAllUris(uris())
                 .connectTimeout(connectTimeout().map(HumanReadableDuration::asConjure))
                 .readTimeout(readTimeout().map(HumanReadableDuration::asConjure))
+                .writeTimeout(writeTimeout().map(HumanReadableDuration::asConjure))
                 .maxNumRetries(maxNumRetries())
                 .backoffSlotSize(backoffSlotSize().map(HumanReadableDuration::asConjure))
                 .enableGcmCipherSuites(enableGcmCipherSuites())

--- a/service-config/src/main/java/com/palantir/remoting/api/config/service/ProxyConfiguration.java
+++ b/service-config/src/main/java/com/palantir/remoting/api/config/service/ProxyConfiguration.java
@@ -103,6 +103,7 @@ public abstract class ProxyConfiguration {
     public com.palantir.conjure.java.api.config.service.ProxyConfiguration asConjure() {
         return com.palantir.conjure.java.api.config.service.ProxyConfiguration.builder()
                 .hostAndPort(hostAndPort())
+                .type(com.palantir.conjure.java.api.config.service.ProxyConfiguration.Type.valueOf(type().toString()))
                 .credentials(credentials().map(BasicCredentials::asConjure))
                 .build();
     }

--- a/service-config/src/main/java/com/palantir/remoting/api/config/service/ProxyConfiguration.java
+++ b/service-config/src/main/java/com/palantir/remoting/api/config/service/ProxyConfiguration.java
@@ -99,6 +99,14 @@ public abstract class ProxyConfiguration {
         }
     }
 
+    @Value.Lazy
+    public com.palantir.conjure.java.api.config.service.ProxyConfiguration asConjure() {
+        return com.palantir.conjure.java.api.config.service.ProxyConfiguration.builder()
+                .hostAndPort(hostAndPort())
+                .credentials(credentials().map(BasicCredentials::asConjure))
+                .build();
+    }
+
     public static ProxyConfiguration of(String hostAndPort) {
         return builder().hostAndPort(hostAndPort).build();
     }

--- a/service-config/src/main/java/com/palantir/remoting/api/config/service/ServiceConfiguration.java
+++ b/service-config/src/main/java/com/palantir/remoting/api/config/service/ServiceConfiguration.java
@@ -64,6 +64,7 @@ public interface ServiceConfiguration {
                 .readTimeout(readTimeout())
                 .writeTimeout(writeTimeout())
                 .maxNumRetries(maxNumRetries())
+                .backoffSlotSize(backoffSlotSize())
                 .enableGcmCipherSuites(enableGcmCipherSuites())
                 .proxy(proxy().map(ProxyConfiguration::asConjure))
                 .build();

--- a/service-config/src/main/java/com/palantir/remoting/api/config/service/ServiceConfiguration.java
+++ b/service-config/src/main/java/com/palantir/remoting/api/config/service/ServiceConfiguration.java
@@ -54,5 +54,20 @@ public interface ServiceConfiguration {
         return new Builder();
     }
 
+    @Value.Lazy
+    default com.palantir.conjure.java.api.config.service.ServiceConfiguration asConjure() {
+        return com.palantir.conjure.java.api.config.service.ServiceConfiguration.builder()
+                .apiToken(apiToken())
+                .security(security().asConjure())
+                .addAllUris(uris())
+                .connectTimeout(connectTimeout())
+                .readTimeout(readTimeout())
+                .writeTimeout(writeTimeout())
+                .maxNumRetries(maxNumRetries())
+                .enableGcmCipherSuites(enableGcmCipherSuites())
+                .proxy(proxy().map(ProxyConfiguration::asConjure))
+                .build();
+    }
+
     class Builder extends ImmutableServiceConfiguration.Builder {}
 }

--- a/service-config/src/main/java/com/palantir/remoting/api/config/service/ServicesConfigBlock.java
+++ b/service-config/src/main/java/com/palantir/remoting/api/config/service/ServicesConfigBlock.java
@@ -24,6 +24,8 @@ import com.palantir.remoting.api.config.ssl.SslConfiguration;
 import com.palantir.tokens.auth.BearerToken;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
+import org.immutables.value.Value;
 import org.immutables.value.Value.Immutable;
 
 /**
@@ -97,6 +99,25 @@ public abstract class ServicesConfigBlock {
     @JsonProperty("enableGcmCipherSuites")
     @JsonAlias("enable-gcm-cipher-suites")
     public abstract Optional<Boolean> defaultEnableGcmCipherSuites();
+
+    @Value.Lazy
+    public com.palantir.conjure.java.api.config.service.ServicesConfigBlock asConjure() {
+        return com.palantir.conjure.java.api.config.service.ServicesConfigBlock.builder()
+                .defaultApiToken(defaultApiToken())
+                .defaultSecurity(defaultSecurity().map(SslConfiguration::asConjure))
+                .services(services().entrySet().stream().collect(Collectors.toMap(e -> e.getKey(),
+                        e -> e.getValue().asConjure())))
+                .defaultProxyConfiguration(
+                        defaultProxyConfiguration().map(ProxyConfiguration::asConjure))
+                .defaultConnectTimeout(
+                        defaultConnectTimeout().map(HumanReadableDuration::asConjure))
+                .defaultReadTimeout(defaultReadTimeout().map(HumanReadableDuration::asConjure))
+                .defaultWriteTimeout(defaultWriteTimeout().map(HumanReadableDuration::asConjure))
+                .defaultBackoffSlotSize(
+                        defaultBackoffSlotSize().map(HumanReadableDuration::asConjure))
+                .defaultEnableGcmCipherSuites(defaultEnableGcmCipherSuites())
+                .build();
+    }
 
     public static Builder builder() {
         return new Builder();

--- a/service-config/src/test/java/com/palantir/remoting/api/config/service/PartialServiceConfigurationTest.java
+++ b/service-config/src/test/java/com/palantir/remoting/api/config/service/PartialServiceConfigurationTest.java
@@ -17,11 +17,14 @@
 package com.palantir.remoting.api.config.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.palantir.remoting.api.config.ssl.SslConfiguration;
 import com.palantir.remoting.api.ext.jackson.ObjectMappers;
 import com.palantir.tokens.auth.BearerToken;
+import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.Optional;
 import org.junit.Test;
@@ -76,8 +79,18 @@ public final class PartialServiceConfigurationTest {
                 + "\"enable-gcm-cipher-suites\":null,"
                 + "\"uris\":[],\"proxy-configuration\":null}";
 
-        assertThat(ObjectMappers.newClientObjectMapper().writeValueAsString(serialized)).isEqualTo(camelCase);
+        assertThat(mapper.writeValueAsString(serialized)).isEqualTo(camelCase);
         assertThat(mapper.readValue(camelCase, PartialServiceConfiguration.class)).isEqualTo(serialized);
         assertThat(mapper.readValue(kebabCase, PartialServiceConfiguration.class)).isEqualTo(serialized);
+    }
+
+    @Test
+    public void serDe_remoting_and_conjure_types_are_equivalent() throws IOException {
+        PartialServiceConfiguration remotingConfig = PartialServiceConfiguration.builder().build();
+        com.palantir.conjure.java.api.config.service.PartialServiceConfiguration conjureConfig = remotingConfig.asConjure();
+        String serializedConjureConfig = mapper.writeValueAsString(conjureConfig);
+        assertEquals(mapper.writeValueAsString(remotingConfig), serializedConjureConfig);
+        assertThat(mapper.readValue(serializedConjureConfig, PartialServiceConfiguration.class)).isEqualTo(
+                remotingConfig);
     }
 }

--- a/service-config/src/test/java/com/palantir/remoting/api/config/service/PartialServiceConfigurationTest.java
+++ b/service-config/src/test/java/com/palantir/remoting/api/config/service/PartialServiceConfigurationTest.java
@@ -88,9 +88,6 @@ public final class PartialServiceConfigurationTest {
     public void serDe_remoting_and_conjure_types_are_equivalent() throws IOException {
         PartialServiceConfiguration remotingConfig = PartialServiceConfiguration.builder().build();
         com.palantir.conjure.java.api.config.service.PartialServiceConfiguration conjureConfig = remotingConfig.asConjure();
-        String serializedConjureConfig = mapper.writeValueAsString(conjureConfig);
-        assertEquals(mapper.writeValueAsString(remotingConfig), serializedConjureConfig);
-        assertThat(mapper.readValue(serializedConjureConfig, PartialServiceConfiguration.class)).isEqualTo(
-                remotingConfig);
+        assertEquals(mapper.writeValueAsString(remotingConfig), mapper.writeValueAsString(conjureConfig));
     }
 }

--- a/service-config/src/test/java/com/palantir/remoting/api/config/service/ProxyConfigurationTests.java
+++ b/service-config/src/test/java/com/palantir/remoting/api/config/service/ProxyConfigurationTests.java
@@ -114,9 +114,7 @@ public final class ProxyConfigurationTests {
         ProxyConfiguration remotingConfig = ProxyConfiguration.of("host:80",
                 BasicCredentials.of("username", "password"));
         com.palantir.conjure.java.api.config.service.ProxyConfiguration conjureConfig = remotingConfig.asConjure();
-        String serializedConjureConfig = mapper.writeValueAsString(conjureConfig);
-        assertEquals(mapper.writeValueAsString(remotingConfig), serializedConjureConfig);
-        assertThat(mapper.readValue(serializedConjureConfig, ProxyConfiguration.class)).isEqualTo(remotingConfig);
+        assertEquals(mapper.writeValueAsString(remotingConfig), mapper.writeValueAsString(conjureConfig));
     }
 
 }

--- a/service-config/src/test/java/com/palantir/remoting/api/config/service/ProxyConfigurationTests.java
+++ b/service-config/src/test/java/com/palantir/remoting/api/config/service/ProxyConfigurationTests.java
@@ -109,4 +109,14 @@ public final class ProxyConfigurationTests {
                 .isEqualTo(config);
     }
 
+    @Test
+    public void serDe_remoting_and_conjure_types_are_equivalent() throws IOException {
+        ProxyConfiguration remotingConfig = ProxyConfiguration.of("host:80",
+                BasicCredentials.of("username", "password"));
+        com.palantir.conjure.java.api.config.service.ProxyConfiguration conjureConfig = remotingConfig.asConjure();
+        String serializedConjureConfig = mapper.writeValueAsString(conjureConfig);
+        assertEquals(mapper.writeValueAsString(remotingConfig), serializedConjureConfig);
+        assertThat(mapper.readValue(serializedConjureConfig, ProxyConfiguration.class)).isEqualTo(remotingConfig);
+    }
+
 }

--- a/ssl-config/build.gradle
+++ b/ssl-config/build.gradle
@@ -4,6 +4,7 @@ apply from: "${rootDir}/gradle/publish-jar.gradle"
 
 dependencies {
     compile "com.fasterxml.jackson.core:jackson-databind"
+    compile "com.palantir.conjure.java.api:ssl-config"
 
     testCompile project(':extras:jackson-support')
     testCompile "org.assertj:assertj-core"

--- a/ssl-config/src/main/java/com/palantir/remoting/api/config/ssl/SslConfiguration.java
+++ b/ssl-config/src/main/java/com/palantir/remoting/api/config/ssl/SslConfiguration.java
@@ -75,6 +75,22 @@ public abstract class SslConfiguration {
         }
     }
 
+    @Value.Lazy
+    public com.palantir.conjure.java.api.config.ssl.SslConfiguration asConjure() {
+        return com.palantir.conjure.java.api.config.ssl.SslConfiguration.builder()
+                .trustStorePath(trustStorePath())
+                .trustStoreType(
+                        com.palantir.conjure.java.api.config.ssl.SslConfiguration.StoreType.valueOf(
+                                trustStoreType().name()))
+                .keyStorePath(keyStorePath())
+                .keyStorePassword(keyStorePassword())
+                .keyStoreType(
+                        com.palantir.conjure.java.api.config.ssl.SslConfiguration.StoreType.valueOf(
+                                keyStoreType().name()))
+                .keyStoreKeyAlias(keyStoreKeyAlias())
+                .build();
+    }
+
     public static SslConfiguration of(Path trustStorePath) {
         return SslConfiguration.builder().trustStorePath(trustStorePath).build();
     }

--- a/ssl-config/src/test/java/com/palantir/remoting/api/config/ssl/SerializationTests.java
+++ b/ssl-config/src/test/java/com/palantir/remoting/api/config/ssl/SerializationTests.java
@@ -62,10 +62,14 @@ public final class SerializationTests {
 
     @Test
     public void serDe_remoting_and_conjure_types_are_equivalent() throws IOException {
-        SslConfiguration remotingConfig = SslConfiguration.of(
-                CA_TRUST_STORE_PATH,
-                SERVER_KEY_STORE_JKS_PATH,
-                SERVER_KEY_STORE_JKS_PASSWORD);
+        SslConfiguration remotingConfig = SslConfiguration.builder()
+                .trustStorePath(CA_TRUST_STORE_PATH)
+                .keyStorePath(SERVER_KEY_STORE_JKS_PATH)
+                .keyStorePassword(SERVER_KEY_STORE_JKS_PASSWORD)
+                .keyStoreKeyAlias("private")
+                .keyStoreType(SslConfiguration.StoreType.JKS)
+                .trustStoreType(SslConfiguration.StoreType.JKS)
+                .build();
 
         com.palantir.conjure.java.api.config.ssl.SslConfiguration conjureConfig = remotingConfig.asConjure();
         assertEquals(MAPPER.writeValueAsString(remotingConfig), MAPPER.writeValueAsString(conjureConfig));

--- a/ssl-config/src/test/java/com/palantir/remoting/api/config/ssl/SerializationTests.java
+++ b/ssl-config/src/test/java/com/palantir/remoting/api/config/ssl/SerializationTests.java
@@ -17,6 +17,7 @@
 package com.palantir.remoting.api.config.ssl;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.palantir.remoting.api.ext.jackson.ObjectMappers;
@@ -57,6 +58,20 @@ public final class SerializationTests {
                 SERVER_KEY_STORE_JKS_PASSWORD);
 
         assertThat(MAPPER.readValue(JSON_STRING, SslConfiguration.class)).isEqualTo(sslConfig);
+    }
+
+    @Test
+    public void serDe_remoting_and_conjure_types_are_equivalent() throws IOException {
+        SslConfiguration remotingConfig = SslConfiguration.of(
+                CA_TRUST_STORE_PATH,
+                SERVER_KEY_STORE_JKS_PATH,
+                SERVER_KEY_STORE_JKS_PASSWORD);
+
+        com.palantir.conjure.java.api.config.ssl.SslConfiguration conjureConfig = remotingConfig.asConjure();
+        String serializedConjureConfig = MAPPER.writeValueAsString(conjureConfig);
+        assertEquals(MAPPER.writeValueAsString(remotingConfig), serializedConjureConfig);
+        assertThat(MAPPER.readValue(serializedConjureConfig, SslConfiguration.class)).isEqualTo(
+                remotingConfig);
     }
 
     private static final String JSON_STRING =

--- a/ssl-config/src/test/java/com/palantir/remoting/api/config/ssl/SerializationTests.java
+++ b/ssl-config/src/test/java/com/palantir/remoting/api/config/ssl/SerializationTests.java
@@ -68,10 +68,7 @@ public final class SerializationTests {
                 SERVER_KEY_STORE_JKS_PASSWORD);
 
         com.palantir.conjure.java.api.config.ssl.SslConfiguration conjureConfig = remotingConfig.asConjure();
-        String serializedConjureConfig = MAPPER.writeValueAsString(conjureConfig);
-        assertEquals(MAPPER.writeValueAsString(remotingConfig), serializedConjureConfig);
-        assertThat(MAPPER.readValue(serializedConjureConfig, SslConfiguration.class)).isEqualTo(
-                remotingConfig);
+        assertEquals(MAPPER.writeValueAsString(remotingConfig), MAPPER.writeValueAsString(conjureConfig));
     }
 
     private static final String JSON_STRING =

--- a/versions.props
+++ b/versions.props
@@ -3,6 +3,7 @@ com.google.code.findbugs:jsr305 = 3.0.1
 com.google.guava:guava = 18.0
 com.palantir.safe-logging:safe-logging = 0.1.3
 com.palantir.tokens:auth-tokens = 3.0.0
+com.palantir.conjure.java.api:* = 2.0.0-rc4
 javax.ws.rs:javax.ws.rs-api = 2.0.1
 junit:junit = 4.12
 org.apache.commons:commons-lang3 = 3.6


### PR DESCRIPTION
Add adapter methods to help converting existing configuration classes to the pacakages as result  of the http-remoting rebranding.