### PR TITLE
[fix] Re-add SerializableError backcompat fields as write-only

### DIFF
--- a/errors/build.gradle
+++ b/errors/build.gradle
@@ -6,6 +6,7 @@ dependencies {
     compile "com.fasterxml.jackson.core:jackson-databind"
     compile "com.google.code.findbugs:jsr305"
     compile "com.palantir.safe-logging:safe-logging"
+    compile "com.palantir.safe-logging:preconditions"
     compile "javax.ws.rs:javax.ws.rs-api"
 
     testCompile project(":extras:jackson-support")

--- a/errors/build.gradle
+++ b/errors/build.gradle
@@ -6,8 +6,8 @@ dependencies {
     compile "com.fasterxml.jackson.core:jackson-databind"
     compile "com.google.code.findbugs:jsr305"
     compile "com.palantir.safe-logging:safe-logging"
-    compile "com.palantir.safe-logging:preconditions"
     compile "javax.ws.rs:javax.ws.rs-api"
+    implementation "com.palantir.safe-logging:preconditions"
 
     testCompile project(":extras:jackson-support")
     testCompile "org.assertj:assertj-core"

--- a/errors/src/main/java/com/palantir/conjure/java/api/errors/SerializableError.java
+++ b/errors/src/main/java/com/palantir/conjure/java/api/errors/SerializableError.java
@@ -47,8 +47,6 @@ public abstract class SerializableError implements Serializable {
      * and/or name.
      */
     @JsonProperty("errorCode")
-    // TODO(rfink): errorCode delegates to exceptionClass if it's not set. This is quite a hack and should be removed
-    // when we remove support for the exceptionClass field.
     @Value.Default
     public String errorCode() {
         return getExceptionClass().orElseThrow(() -> new SafeIllegalStateException(
@@ -61,8 +59,6 @@ public abstract class SerializableError implements Serializable {
      * error name via {@link RemoteException#getError} and typically switch&dispatch on the error code and/or name.
      */
     @JsonProperty("errorName")
-    // TODO(rfink): errorName delegates to message if it's not set. This is quite a hack and should be removed when we
-    // remove support for the message field.
     @Value.Default
     public String errorName() {
         return getMessage().orElseThrow(() -> new SafeIllegalStateException(
@@ -92,7 +88,6 @@ public abstract class SerializableError implements Serializable {
     @JsonProperty(value = "exceptionClass", access = JsonProperty.Access.WRITE_ONLY)
     @Value.Auxiliary
     @SuppressWarnings("checkstyle:designforextension")
-    // TODO(rfink): Remove once all error producers have switched to errorCode.
     abstract Optional<String> getExceptionClass();
 
     /**
@@ -102,7 +97,6 @@ public abstract class SerializableError implements Serializable {
     @JsonProperty(value = "message", access = JsonProperty.Access.WRITE_ONLY)
     @Value.Auxiliary
     @SuppressWarnings("checkstyle:designforextension")
-    // TODO(rfink): Remove once all error producers have switched to errorName.
     abstract Optional<String> getMessage();
 
     /**

--- a/errors/src/main/java/com/palantir/conjure/java/api/errors/SerializableError.java
+++ b/errors/src/main/java/com/palantir/conjure/java/api/errors/SerializableError.java
@@ -91,6 +91,7 @@ public abstract class SerializableError implements Serializable {
      */
     @Deprecated
     @JsonProperty(value = "exceptionClass", access = JsonProperty.Access.WRITE_ONLY)
+    @Value.Auxiliary
     @SuppressWarnings("checkstyle:designforextension")
     // TODO(rfink): Remove once all error producers have switched to errorCode.
     abstract Optional<String> getExceptionClass();
@@ -100,6 +101,7 @@ public abstract class SerializableError implements Serializable {
      */
     @Deprecated
     @JsonProperty(value = "message", access = JsonProperty.Access.WRITE_ONLY)
+    @Value.Auxiliary
     @SuppressWarnings("checkstyle:designforextension")
     // TODO(rfink): Remove once all error producers have switched to errorName.
     abstract Optional<String> getMessage();

--- a/errors/src/main/java/com/palantir/conjure/java/api/errors/SerializableError.java
+++ b/errors/src/main/java/com/palantir/conjure/java/api/errors/SerializableError.java
@@ -47,9 +47,8 @@ public abstract class SerializableError implements Serializable {
      * and/or name.
      */
     @JsonProperty("errorCode")
-    // TODO(rfink): errorCode and exceptionClass are mutual delagates so that they can be either set independently or
-    // one inherits from the other. This is quite a hack and should be removed when we remove support for the
-    // exceptionClass field.
+    // TODO(rfink): errorCode delegates to exceptionClass if it's not set. This is quite a hack and should be removed
+    // when we remove support for the exceptionClass field.
     @Value.Default
     public String errorCode() {
         return getExceptionClass().orElseThrow(() -> new SafeIllegalStateException(
@@ -62,8 +61,8 @@ public abstract class SerializableError implements Serializable {
      * error name via {@link RemoteException#getError} and typically switch&dispatch on the error code and/or name.
      */
     @JsonProperty("errorName")
-    // TODO(rfink): errorName and message are mutual delagates so that they can be either set independently or one
-    // inherits from the other. This is quite a hack and should be removed when we remove support for the message field.
+    // TODO(rfink): errorName delegates to message if it's not set. This is quite a hack and should be removed when we
+    // remove support for the message field.
     @Value.Default
     public String errorName() {
         return getMessage().orElseThrow(() -> new SafeIllegalStateException(

--- a/errors/src/main/java/com/palantir/conjure/java/api/errors/SerializableError.java
+++ b/errors/src/main/java/com/palantir/conjure/java/api/errors/SerializableError.java
@@ -45,7 +45,13 @@ public abstract class SerializableError implements Serializable {
      * and/or name.
      */
     @JsonProperty("errorCode")
-    public abstract String errorCode();
+    // TODO(rfink): errorCode and exceptionClass are mutual delagates so that they can be either set independently or
+    // one inherits from the other. This is quite a hack and should be removed when we remove support for the
+    // exceptionClass field.
+    @Value.Default
+    public String errorCode() {
+        return getExceptionClass();
+    }
 
     /**
      * A fixed name identifying the error. For errors generated from {@link ServiceException}, this corresponding to the
@@ -53,7 +59,12 @@ public abstract class SerializableError implements Serializable {
      * error name via {@link RemoteException#getError} and typically switch&dispatch on the error code and/or name.
      */
     @JsonProperty("errorName")
-    public abstract String errorName();
+    // TODO(rfink): errorName and message are mutual delagates so that they can be either set independently or one
+    // inherits from the other. This is quite a hack and should be removed when we remove support for the message field.
+    @Value.Default
+    public String errorName() {
+        return getMessage();
+    }
 
     /**
      * A unique identifier for this error instance, typically used to correlate errors displayed in user-facing
@@ -70,6 +81,30 @@ public abstract class SerializableError implements Serializable {
 
     /** A set of parameters that further explain the error. */
     public abstract Map<String, String> parameters();
+
+    /**
+     * @deprecated Used by the serialization-mechanism for back-compat only. Do not use.
+     */
+    @Deprecated
+    @Value.Default
+    @JsonProperty(value = "exceptionClass", access = JsonProperty.Access.WRITE_ONLY)
+    @SuppressWarnings("checkstyle:designforextension")
+    // TODO(rfink): Remove once all error producers have switched to errorCode.
+    String getExceptionClass() {
+        return errorCode();
+    }
+
+    /**
+     * @deprecated Used by the serialization-mechanism for back-compat only. Do not use.
+     */
+    @Deprecated
+    @Value.Default
+    @JsonProperty(value = "message", access = JsonProperty.Access.WRITE_ONLY)
+    @SuppressWarnings("checkstyle:designforextension")
+    // TODO(rfink): Remove once all error producers have switched to errorName.
+    String getMessage() {
+        return errorName();
+    }
 
     /**
      * Creates a {@link SerializableError} representation of this exception that derives from the error code and

--- a/errors/src/test/java/com/palantir/conjure/java/api/errors/SerializableErrorTest.java
+++ b/errors/src/test/java/com/palantir/conjure/java/api/errors/SerializableErrorTest.java
@@ -84,7 +84,9 @@ public final class SerializableErrorTest {
     public void testDeserializesWhenRedundantParamerersAreGiven() throws Exception {
         String serialized =
                 "{\"errorCode\":\"code\",\"errorName\":\"name\",\"exceptionClass\":\"code\",\"message\":\"name\"}";
-        assertThat(deserialize(serialized)).isEqualTo(ERROR);
+        assertThat(deserialize(serialized))
+                .isEqualTo(SerializableError.builder()
+                        .from(ERROR).exceptionClass("code").message("name").build());
     }
 
     @Test
@@ -105,7 +107,7 @@ public final class SerializableErrorTest {
         String serialized = "{\"errorCode\":\"code\"}";
         assertThatThrownBy(() -> deserialize(serialized))
                 .isInstanceOf(IllegalStateException.class)
-                .hasMessage("Cannot build SerializableError, some of required attributes are not set [errorName]");
+                .hasMessage("Expected either 'errorName' or 'message' to be set");
     }
 
     private static SerializableError deserialize(String serialized) throws IOException {

--- a/errors/src/test/java/com/palantir/conjure/java/api/errors/SerializableErrorTest.java
+++ b/errors/src/test/java/com/palantir/conjure/java/api/errors/SerializableErrorTest.java
@@ -84,9 +84,7 @@ public final class SerializableErrorTest {
     public void testDeserializesWhenRedundantParamerersAreGiven() throws Exception {
         String serialized =
                 "{\"errorCode\":\"code\",\"errorName\":\"name\",\"exceptionClass\":\"code\",\"message\":\"name\"}";
-        assertThat(deserialize(serialized))
-                .isEqualTo(SerializableError.builder()
-                        .from(ERROR).exceptionClass("code").message("name").build());
+        assertThat(deserialize(serialized)).isEqualTo(ERROR);
     }
 
     @Test

--- a/errors/versions.lock
+++ b/errors/versions.lock
@@ -56,20 +56,8 @@
         "com.google.code.findbugs:jsr305": {
             "locked": "3.0.1"
         },
-        "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.1.3",
-            "transitive": [
-                "com.palantir.safe-logging:preconditions"
-            ]
-        },
-        "com.palantir.safe-logging:preconditions": {
-            "locked": "1.5.0"
-        },
         "com.palantir.safe-logging:safe-logging": {
-            "locked": "1.5.0",
-            "transitive": [
-                "com.palantir.safe-logging:preconditions"
-            ]
+            "locked": "1.5.0"
         },
         "javax.ws.rs:javax.ws.rs-api": {
             "locked": "2.0.1"

--- a/errors/versions.lock
+++ b/errors/versions.lock
@@ -18,8 +18,20 @@
         "com.google.code.findbugs:jsr305": {
             "locked": "3.0.1"
         },
-        "com.palantir.safe-logging:safe-logging": {
+        "com.google.errorprone:error_prone_annotations": {
+            "locked": "2.1.3",
+            "transitive": [
+                "com.palantir.safe-logging:preconditions"
+            ]
+        },
+        "com.palantir.safe-logging:preconditions": {
             "locked": "1.5.0"
+        },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "1.5.0",
+            "transitive": [
+                "com.palantir.safe-logging:preconditions"
+            ]
         },
         "javax.ws.rs:javax.ws.rs-api": {
             "locked": "2.0.1"
@@ -44,8 +56,20 @@
         "com.google.code.findbugs:jsr305": {
             "locked": "3.0.1"
         },
-        "com.palantir.safe-logging:safe-logging": {
+        "com.google.errorprone:error_prone_annotations": {
+            "locked": "2.1.3",
+            "transitive": [
+                "com.palantir.safe-logging:preconditions"
+            ]
+        },
+        "com.palantir.safe-logging:preconditions": {
             "locked": "1.5.0"
+        },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "1.5.0",
+            "transitive": [
+                "com.palantir.safe-logging:preconditions"
+            ]
         },
         "javax.ws.rs:javax.ws.rs-api": {
             "locked": "2.0.1"

--- a/test-utils/versions.lock
+++ b/test-utils/versions.lock
@@ -24,13 +24,26 @@
                 "com.palantir.conjure.java.api:errors"
             ]
         },
+        "com.google.errorprone:error_prone_annotations": {
+            "locked": "2.1.3",
+            "transitive": [
+                "com.palantir.safe-logging:preconditions"
+            ]
+        },
         "com.palantir.conjure.java.api:errors": {
             "project": true
+        },
+        "com.palantir.safe-logging:preconditions": {
+            "locked": "1.5.0",
+            "transitive": [
+                "com.palantir.conjure.java.api:errors"
+            ]
         },
         "com.palantir.safe-logging:safe-logging": {
             "locked": "1.5.0",
             "transitive": [
-                "com.palantir.conjure.java.api:errors"
+                "com.palantir.conjure.java.api:errors",
+                "com.palantir.safe-logging:preconditions"
             ]
         },
         "javax.ws.rs:javax.ws.rs-api": {
@@ -87,13 +100,26 @@
                 "com.palantir.conjure.java.api:errors"
             ]
         },
+        "com.google.errorprone:error_prone_annotations": {
+            "locked": "2.1.3",
+            "transitive": [
+                "com.palantir.safe-logging:preconditions"
+            ]
+        },
         "com.palantir.conjure.java.api:errors": {
             "project": true
+        },
+        "com.palantir.safe-logging:preconditions": {
+            "locked": "1.5.0",
+            "transitive": [
+                "com.palantir.conjure.java.api:errors"
+            ]
         },
         "com.palantir.safe-logging:safe-logging": {
             "locked": "1.5.0",
             "transitive": [
-                "com.palantir.conjure.java.api:errors"
+                "com.palantir.conjure.java.api:errors",
+                "com.palantir.safe-logging:preconditions"
             ]
         },
         "javax.ws.rs:javax.ws.rs-api": {

--- a/test-utils/versions.lock
+++ b/test-utils/versions.lock
@@ -24,26 +24,13 @@
                 "com.palantir.conjure.java.api:errors"
             ]
         },
-        "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.1.3",
-            "transitive": [
-                "com.palantir.safe-logging:preconditions"
-            ]
-        },
         "com.palantir.conjure.java.api:errors": {
             "project": true
-        },
-        "com.palantir.safe-logging:preconditions": {
-            "locked": "1.5.0",
-            "transitive": [
-                "com.palantir.conjure.java.api:errors"
-            ]
         },
         "com.palantir.safe-logging:safe-logging": {
             "locked": "1.5.0",
             "transitive": [
-                "com.palantir.conjure.java.api:errors",
-                "com.palantir.safe-logging:preconditions"
+                "com.palantir.conjure.java.api:errors"
             ]
         },
         "javax.ws.rs:javax.ws.rs-api": {


### PR DESCRIPTION
This reverts the removals that occurred here: https://github.com/palantir/http-remoting-api/pull/100/files#diff-1604ffe60cf0f42a265fa29f94cbf660
And re-adds the fallback onto the old fields `exceptionClass` and `message` but in a cleaner way:
- no more weird exception message because of the cycles between `exceptionClass` <-> `errorCode` and `message` <-> `errorName`
- explicit, SafeLoggable errors when the required field as well as its fallback are both missing
- deprecated fallback fields no longer participate in equals, hashCode, toString; they are only used as a fallback if the original field wasn't set, otherwise they are essentially dropped