### PR TITLE
Update rootProject.name to 'conjure-java-runtime-api'

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,4 @@
-rootProject.name = 'http-remoting-api'
+rootProject.name = 'conjure-java-runtime-api'
 
 include 'errors'
 include 'service-config'


### PR DESCRIPTION
This will require updated bintray entitlements (internal PR 49).

Follow-up to https://github.com/palantir/http-remoting-api/pull/117